### PR TITLE
corrected the path to the generated build docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ To build and view an HTML version of the documentation::
     $ cd docs
     $ pip install sphinx
     $ make html
-    $ firefox _build/index.html
+    $ firefox _build/html/index.html
 
 
 Related repositories


### PR DESCRIPTION
A wee-small update to the readme - the html docs are being generated in <code>docs/_build/html/index.html</code> and not <code>docs/_build/index.html</code>
