### PR TITLE
Remove display of priority from _case_details as it seems unnecesary and creates a display issue

### DIFF
--- a/templates/manage/case/list/_case_details.html
+++ b/templates/manage/case/list/_case_details.html
@@ -2,9 +2,6 @@
 
 <div class="iteminfo">
   {% include "lists/_case_byline.html" with item=caseversion %}
-  <div class="priority">
-    <span class="priority-title">Priority:</span> {{ caseversion.case.priority }}
-  </div>
 
   {% if caseversion.description %}
     <p class="description">


### PR DESCRIPTION
This is my attempt to address https://bugzilla.mozilla.org/show_bug.cgi?id=909475. I realize I'm probably mistaken, but I cannot see anywhere that we would need to display the priority via this template, as the priority should appear in the listing above the details. If simply removing this is a problem, please let me know where we do need it displayed.
