### PR TITLE
Bug 932722 - Author is unknown when add new version of existing test case

### DIFF
--- a/moztrap/view/manage/cases/views.py
+++ b/moztrap/view/manage/cases/views.py
@@ -191,7 +191,8 @@ def caseversion_clone(request, caseversion_id):
             overrides={
                 "productversion": productversion,
                 "name": caseversion.name
-                }
+                },
+            user=request.user
             )
         messages.success(
             request,


### PR DESCRIPTION
As commit message,
in `show details`, creator is the exact one who created the new version case instead of `unknown` after applied this patch.
