### PR TITLE
scroll to top when switching page in Manage/Results list

### DIFF
--- a/static/js/listpages.js
+++ b/static/js/listpages.js
@@ -81,6 +81,7 @@ var MT = (function (MT, $) {
             $.get(url, function (response) {
                 var newList = $(response.html);
                 replaceList.loadingOverlay('remove');
+                $('html, body').animate({scrollTop: replaceList.offset().top}, 0);
                 if (response.html) {
                     replaceList.replaceWith(newList);
                     newList.find('.details').html5accordion();


### PR DESCRIPTION
when we switch between pages, moztrap should scroll back to top of the page instead of staying at the bottom.
