### PR TITLE
Prevent overlong case name when creating bulk cases

### DIFF
--- a/moztrap/model/library/bulk.py
+++ b/moztrap/model/library/bulk.py
@@ -71,6 +71,7 @@ class BulkParser(object):
         """The start state."""
         if lc.startswith("test that "):
             if len(orig) > 200:
+                data.append({})
                 raise ParsingError("Title should have at most 200 chracters, '%s...'" % orig[0:50])
             data.append({"name": orig})
             return self.description
@@ -111,6 +112,7 @@ class BulkParser(object):
             return self.after_and
         if lc.startswith("test that "):
             if len(orig) > 200:
+                data.append({})
                 raise ParsingError("Title should have at most 200 chracters, '%s...'" % orig[0:50])
             data.append({"name": orig})
             return self.description

--- a/tests/model/library/test_bulk.py
+++ b/tests/model/library/test_bulk.py
@@ -330,3 +330,60 @@ class ParseBulkTest(case.TestCase):
                     },
                 ]
             )
+
+
+    def test_overlong_name_in_first_case(self):
+        """Overlong name causes error."""
+        self.assertEqual(
+            self.parser().parse(
+                textwrap.dedent("""
+                Test That a super long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long name
+                When the name is overlong
+                Then causes error
+                """)
+                ),
+            [
+                {
+                    "error": (
+                        "Title should have at most 200 chracters, '"
+                        "Test That a super long long long long long long lo"
+                        "...'"
+                        ),
+                    },
+                ]
+            )
+
+
+    def test_overlong_name_in_another_case(self):
+        """Overlong name causes error."""
+        self.assertEqual(
+            self.parser().parse(
+                textwrap.dedent("""
+                Test that a perfectly good name
+                when ever you are
+                Test That a super long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long name
+                When the name is overlong
+                Then causes error
+                """)
+                ),
+            [
+                {
+                    "name": "Test that a perfectly good name",
+                    "description": "",
+                    "steps": [
+                        {
+                            "instruction": (
+                                "when ever you are"
+                                ),
+                            },
+                        ]
+                    },
+                {
+                    "error": (
+                        "Title should have at most 200 chracters, '"
+                        "Test That a super long long long long long long lo"
+                        "...'"
+                        ),
+                    },
+                ]
+            )


### PR DESCRIPTION
In `create bulk cases`, adding a case with overlong name (> 200 characters) is allowed, but it should not be allowed.
