### PR TITLE
New Relic support

### DIFF
--- a/moztrap/deploy/vendor_wsgi.py
+++ b/moztrap/deploy/vendor_wsgi.py
@@ -6,6 +6,19 @@ dependencies.
 import os
 import sys
 
+try:
+    import newrelic.agent
+except ImportError:
+    newrelic = False
+
+
+if newrelic:
+    newrelic_ini = os.getenv('NEWRELIC_PYTHON_INI_FILE', False)
+    if newrelic_ini:
+        newrelic.agent.initialize(newrelic_ini)
+    else:
+        newrelic = False
+
 base_dir = os.path.dirname(
     os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 sys.path.insert(0, base_dir)
@@ -19,3 +32,6 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "moztrap.settings.default")
 
 from django.core.handlers.wsgi import WSGIHandler
 application = WSGIHandler()
+
+if newrelic:
+    application = newrelic.agent.wsgi_application()(application)


### PR DESCRIPTION
Pretty straightforward tweak to the WSGI file to add New Relic support. Untested, but code pulled straight from https://github.com/mozilla/bedrock/blob/master/wsgi/playdoh.wsgi so it should be pretty solid.
