### PR TITLE
Expanded REST API

### DIFF
--- a/moztrap/model/core/api.py
+++ b/moztrap/model/core/api.py
@@ -196,3 +196,4 @@ class UserResource(ModelResource):
         queryset = User.objects.all()
         list_allowed_methods = ['get']
         fields = ["id", "username"]
+        filtering = {"username": ALL}

--- a/moztrap/model/mtapi.py
+++ b/moztrap/model/mtapi.py
@@ -4,6 +4,7 @@ from tastypie.authorization import  Authorization
 from tastypie.exceptions import ImmediateHttpResponse
 from tastypie.resources import ModelResource
 
+from django.http import HttpResponse
 from .core.models import ApiKey
 
 import logging
@@ -195,8 +196,16 @@ class MTResource(ModelResource):
         return content.
         """
         res = super(MTResource, self).delete_detail(request, **kwargs)
-        del(res._headers["content-type"])
-        return res
+        # FIXME: By TastyPie default, DELETE returns 204 No Content
+        # But message_ui middleware has problem with response with no
+        # content-type.
+        # Replace the rest of the method with these after message_ui updated:
+        #    del(res._headers["content-type"])
+        #    return res
+        if (res.status_code == 204):
+            return HttpResponse()
+        else:
+            return res
 
 
     def save_related(self, bundle):

--- a/tests/case/api/crud.py
+++ b/tests/case/api/crud.py
@@ -338,6 +338,11 @@ class ApiCrudCases(ApiTestCase):
             self.backend_data(fixture2)
             ]
 
+        # Monkey patch the expected modified time for testing
+        for exp_object in exp_objects:
+            if u'modified_on' in exp_object:
+                exp_object[u'modified_on'] = u'2011-12-13T22:39:00'
+
         self.maxDiff = None
         self.assertEqual(exp_objects, act_objects)
 
@@ -385,6 +390,9 @@ class ApiCrudCases(ApiTestCase):
         actual = res.json
 
         expected = self.backend_data(fixture1)
+
+        if u'modified_on' in expected:
+            expected[u'modified_on'] = u'2011-12-13T22:39:00'
 
         self.maxDiff = None
         self.assertEqual(expected, actual)
@@ -566,7 +574,8 @@ class ApiCrudCases(ApiTestCase):
         # do delete
         params = self.credentials
         params.update({"permanent": True})
-        self.delete(self.resource_name, obj_id, params=params, status=204)
+        # FIXME: status for delete should be 204, see moztrap/model/mtapi.py
+        self.delete(self.resource_name, obj_id, params=params, status=200)
 
         from django.core.exceptions import ObjectDoesNotExist
 
@@ -598,11 +607,12 @@ class ApiCrudCases(ApiTestCase):
         self.assertIsNone(meta_before_delete["deleted_by"])
 
         # do delete
+        # FIXME: status for delete should be 204, see moztrap/model/mtapi.py
         self.delete(
             self.resource_name,
             obj_id,
             params=self.credentials,
-            status=204)
+            status=200)
 
         # check meta data after
         meta_after_delete = self.backend_meta_data(

--- a/tests/model/execution/api/test_runcaseversion.py
+++ b/tests/model/execution/api/test_runcaseversion.py
@@ -5,6 +5,7 @@ Tests for RunCaseVersionResource api.
 
 from tests import case
 
+from datetime import datetime
 
 
 class RunCaseVersionResourceTest(case.api.ApiTestCase):
@@ -54,13 +55,18 @@ class RunCaseVersionResourceTest(case.api.ApiTestCase):
             exp_objects.append({
                 u"caseversion": {
                     u"case": unicode(self.get_detail_url("case", cv.case.id)),
+                    u"created_by": None,
                     u"description": unicode(cv.description),
-                    u'environments': [],
+                    u"environments": [],
                     u"id": unicode(cv.id),
+                    u"modified_by": None,
+                    u"modified_on": unicode(cv.modified_on.strftime("%Y-%m-%dT%H:%M:%S")),
                     u"name": unicode(cv.name),
+                    u"priority": unicode(None),
                     u"productversion": unicode(self.get_detail_url(
                         "productversion",
                         cv.productversion.id)),
+                    u"productversion_name": unicode(cv.productversion.name),
                     u"resource_uri": unicode(self.get_detail_url(
                         "caseversion",
                         cv.id,

--- a/tests/model/library/api/test_case_resource.py
+++ b/tests/model/library/api/test_case_resource.py
@@ -10,7 +10,6 @@ import logging
 mozlogger = logging.getLogger('moztrap.test')
 
 
-
 class CaseResourceTest(ApiCrudCases):
 
     @property
@@ -127,6 +126,8 @@ class CaseSelectionResourceTest(case.api.ApiTestCase):
                 self.get_detail_url("case", cv.case.id)),
             u"case_id": unicode(cv.case.id),
             u"created_by": None,
+            u"modified_by": None,
+            u"modified_on": unicode(cv.modified_on.strftime("%Y-%m-%dT%H:%M:%S")),
             u"id": unicode(cv.id),
             u"name": unicode(cv.name),
             u'priority': unicode(None),

--- a/tests/model/library/api/test_caseversion_resource.py
+++ b/tests/model/library/api/test_caseversion_resource.py
@@ -9,7 +9,6 @@ from tests.case.api.crud import ApiCrudCases
 import logging
 mozlogger = logging.getLogger('moztrap.test')
 
-from datetime import datetime
 
 class CaseVersionResourceTest(ApiCrudCases):
 
@@ -49,10 +48,15 @@ class CaseVersionResourceTest(ApiCrudCases):
         fields = {
             u"case": unicode(self.get_detail_url(
                 "case", self.case_fixture.id)),
+            u"created_by": None,
+            u"modified_by": None,
+            u"modified_on": unicode(self.utcnow.strftime("%Y-%m-%dT%H:%M:%S")),
             u"name": unicode("test_%s_%s" % modifiers),
             u"description": unicode("test %s %s" % modifiers),
             u"productversion": unicode(self.get_detail_url(
                 "productversion", self.productversion_fixture.id)),
+            u"productversion_name": unicode(self.productversion_fixture.name),
+            u"priority": unicode("None"),
             u"status": unicode("draft"),
             u"environments": [],
             u"tags": [],
@@ -82,10 +86,15 @@ class CaseVersionResourceTest(ApiCrudCases):
         actual[u"case"] = unicode(
             self.get_detail_url("case", str(backend_obj.case.id)))
         actual[u"name"] = unicode(backend_obj.name)
+        actual[u"created_by"] = None
+        actual[u"modified_by"] = None
+        actual[u"modified_on"] = unicode(backend_obj.modified_on.strftime("%Y-%m-%dT%H:%M:%S"))
+        actual[u"priority"] = unicode(None)
         actual[u"description"] = unicode(backend_obj.description)
         actual[u"productversion"] = unicode(
             self.get_detail_url("productversion",
                 backend_obj.productversion.id))
+        actual[u"productversion_name"] = unicode(backend_obj.productversion.name)
         actual[u"status"] = unicode(backend_obj.status)
         actual[u"resource_uri"] = unicode(
             self.get_detail_url(self.resource_name, str(backend_obj.id)))
@@ -370,10 +379,10 @@ class CaseVersionSearchResourceTest(case.api.ApiTestCase):
             u"case": unicode(
                 self.get_detail_url("case", cv.case.id)),
             u"case_id": unicode(cv.case.id),
-            u"created_by": unicode(None),
+            u"created_by": None,
             u"id": unicode(cv.id),
-            u"modified_by": unicode(None),
-            u"modified_on": datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S"),
+            u"modified_by": None,
+            u"modified_on": unicode(cv.modified_on.strftime("%Y-%m-%dT%H:%M:%S")),
             u"name": unicode(cv.name),
             u"priority": unicode(None),
             u"productversion": {

--- a/tests/model/library/api/test_suite_resource.py
+++ b/tests/model/library/api/test_suite_resource.py
@@ -8,7 +8,6 @@ from tests import case
 from tests.case.api.crud import ApiCrudCases
 
 
-
 class SuiteResourceTest(ApiCrudCases):
     """Please see the test cases implemented in tests.case.api.ApiCrudCases.
 
@@ -63,6 +62,9 @@ class SuiteResourceTest(ApiCrudCases):
             u"product": unicode(self.get_detail_url(
                 "product", self.product_fixture.id)),
             u"status": unicode("draft"),
+            u"created_by": None,
+            u"modified_by": None,
+            u"modified_on": self.utcnow.strftime("%Y-%m-%d %H:%M:%S"),
         }
         return fields
 
@@ -82,6 +84,9 @@ class SuiteResourceTest(ApiCrudCases):
         Note: both keys and data should be in unicode
         """
         actual = {}
+        actual[u"created_by"] = None
+        actual[u"modified_by"] = None
+        actual[u"modified_on"] = backend_obj.modified_on.strftime("%Y-%m-%d %H:%M:%S")
         actual[u"id"] = unicode(str(backend_obj.id))
         actual[u"name"] = unicode(backend_obj.name)
         actual[u"description"] = unicode(backend_obj.description)


### PR DESCRIPTION
Expanded the REST API to support more filter and order options, also added some fields to the payload. 

Notice I removed `del(res._headers["content-type"])` from the DELETE API response. This will create a warning in unittesting. but if we keep it, doing a DELETE on SuiteCaseResource will result in a 500 server error. 