### PR TITLE
Added django-cors-headers

### DIFF
--- a/moztrap/settings/base.py
+++ b/moztrap/settings/base.py
@@ -247,3 +247,11 @@ BROWSERID_CREATE_USER = "moztrap.model.core.auth.browserid_create_user"
 USE_BROWSERID = True
 
 GOOGLE_ANALYTICS_ID = 'UA-49796218-15'
+
+# Enable CORS
+INSTALLED_APPS += ["corsheaders"]
+MIDDLEWARE_CLASSES += [
+    'corsheaders.middleware.CorsMiddleware',
+    'django.middleware.common.CommonMiddleware'
+]
+CORS_ORIGIN_ALLOW_ALL = True

--- a/requirements/pure.txt
+++ b/requirements/pure.txt
@@ -50,3 +50,7 @@ docutils==0.11
 Sphinx==1.2.2
 sphinxcontrib-httpdomain==1.2.1
 MarkupSafe==0.19
+
+# For CORS
+django-cors-headers==1.0.0
+


### PR DESCRIPTION
Added django-cors-header package to enable CORS requests. Required for building 3rd party UI using the REST API. 
Related: https://github.com/mozilla/moztrap-reqs/pull/4