### PR TITLE
Do not permanently close read-only message

### DIFF
--- a/static/js/general.js
+++ b/static/js/general.js
@@ -14,19 +14,9 @@ var MT = (function (MT, $) {
                 "Database is in READ-ONLY mode. " +
                 $('p', banner).text()
             );
-            // if we have chosen to ignore the warning, let's close it
-            if (window.sessionStorage.getItem('ignore-readonly')) {
-                banner.hide();
-                console.warn(
-                    'To renable the read-only warning enter: ' +
-                    "sessionStorage.removeItem('ignore-readonly');\n" +
-                    'in the Web Console and refresh the page.'
-                );
-            }
         }
         banner.on('click', '.close-button', function(event) {
             event.preventDefault();
-            window.sessionStorage.setItem('ignore-readonly', true);
             banner.fadeOut(500);
         });
     };


### PR DESCRIPTION
As per the discussion in PR #85, this is a temporary fix that causes the warning banner to not permanently disappear when closed. This will allow a user to close the banner if it is currently obstructing other elements, but will not cause them to forget that they saw it on later screens, as it will always come back.

As per the discussion, I'm not sure if we want to do this for now, but it seems like a logical first step to get things moving again.

@peterbe r?
