### PR TITLE
fixes bug 1165411 - Optimize modelfilter choices

### DIFF
--- a/moztrap/model/__init__.py
+++ b/moztrap/model/__init__.py
@@ -2,12 +2,13 @@
 All models.
 
 """
-from django.db.models import ProtectedError
+from django.db.models import ProtectedError, signals
+from django.dispatch import receiver
 
 from registration.models import RegistrationProfile
 
 from .mtmodel import ConcurrencyError
-from .core.models import Product, ProductVersion, ApiKey
+from .core.models import MTModel, Product, ProductVersion, ApiKey
 from .core.auth import User, Role, Permission
 from .environments.models import Environment, Profile, Element, Category
 from .execution.models import Run, RunSuite, RunCaseVersion, Result, StepResult
@@ -18,3 +19,21 @@ from .tags.models import Tag
 
 # version of the REST endpoint APIs for TastyPie
 API_VERSION = "v1"
+
+
+@receiver(signals.post_save, sender=Tag)
+@receiver(signals.post_save, sender=User)
+@receiver(signals.post_save, sender=Role)
+@receiver(signals.post_save, sender=Element)
+@receiver(signals.post_save, sender=Suite)
+@receiver(signals.post_save, sender=Run)
+@receiver(signals.post_save, sender=Product)
+@receiver(signals.post_save, sender=ProductVersion)
+def invalidate_model_choices(sender, instance, **kwargs):
+    """This makes sure that the model choices for forms related to these
+    are invalidated when changes are made.
+
+    The place where the caching is set is in
+    moztrap.view.lists.filters.ModelFilter
+    """
+    MTModel.delete_modelfilter_choices_cache(sender)

--- a/tests/view/lists/test_filters.py
+++ b/tests/view/lists/test_filters.py
@@ -2,9 +2,11 @@
 Tests for queryset-filtering.
 
 """
-from django.http import QueryDict
+
 from mock import Mock
 
+from django.http import QueryDict
+from django.core.cache import cache
 from django.template.response import TemplateResponse
 from django.test import RequestFactory
 from django.utils.datastructures import MultiValueDict
@@ -559,6 +561,11 @@ class ChoicesFilterTest(FiltersTestCase):
 
 class ModelFilterTest(FiltersTestCase):
     """Tests for ModelFilter."""
+
+    def setUp(self):
+        super(ModelFilterTest, self)
+        cache.clear()
+
     @property
     def queryset(self):
         """Mock "queryset" of instances with numeric id and unicode repr."""
@@ -569,6 +576,7 @@ class ModelFilterTest(FiltersTestCase):
         o2.pk = 2
         o2.__unicode__ = lambda self: "two"
         qs = Mock()
+        qs.model._meta = 'some.Model'
         qs.__iter__ = lambda self: iter([o1, o2])
         qs.all.return_value = qs
         return qs

--- a/tests/view/manage/cases/test_views.py
+++ b/tests/view/manage/cases/test_views.py
@@ -20,7 +20,6 @@ class CasesTest(case.view.manage.ListViewTestCase,
     form_id = "manage-cases-form"
     perm = "manage_cases"
 
-
     @property
     def factory(self):
         """The model factory for this manage list."""


### PR DESCRIPTION
@camd r?

This is going to make a HUGE difference. 
Actually, when I tested the pjax URLs with curl, it only became about a second faster. From hovering around 2.5seconds each request to about 1.7seconds. 

But that's (less than) 1 seconds LESS of MySQL CPU burden to worry itself with. Instead of doing 8 big fat select statements on each list, it's now 0. (except every 1 hour is flushes the cache). 

